### PR TITLE
Add support for smartheater sensors

### DIFF
--- a/custom_components/solarwatt_energymanager/sensor_factory.py
+++ b/custom_components/solarwatt_energymanager/sensor_factory.py
@@ -24,6 +24,7 @@ from .energy_manager_sensors import (
     EnergyManagerVoltageSensor,
     EnergyManagerWorkSensor,
 )
+from .smart_heater_device import SmartHeaterDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +55,23 @@ def get_power_meter_device(em: em.EnergyManagerData, guid: str) -> em.PowerMeter
     """Get the Power Meter device with the specified guid."""
     devices = list(filter(lambda d: d.device.guid == guid, em.power_meter_devices))
     return devices[0] if devices else None
+
+
+def get_smart_heater_devices(data: em.EnergyManagerData) -> list[SmartHeaterDevice]:
+    """Get all SmartHeater devices from the raw device map."""
+    return [
+        SmartHeaterDevice(device)
+        for device in data.devices.values()
+        if SmartHeaterDevice.DEVICE_CLASS in device.device_classes
+    ]
+
+
+def get_smart_heater_device(data: em.EnergyManagerData, guid: str) -> SmartHeaterDevice | None:
+    """Get the SmartHeater device with the specified guid."""
+    device = data.devices.get(guid)
+    if device and SmartHeaterDevice.DEVICE_CLASS in device.device_classes:
+        return SmartHeaterDevice(device)
+    return None
 
 
 def get_device_info(data: em.EnergyManagerData) -> DeviceInfo:
@@ -125,6 +143,17 @@ def create_sensors(
             entities.extend(
                 create_power_meter_sensors(
                     coordinator, device_info, powerMeter
+                )
+            )
+    smartHeaters = get_smart_heater_devices(data)
+    smartHeaterCount = len(smartHeaters)
+    if smartHeaterCount > 0:
+        _LOGGER.info(f"Found {smartHeaterCount} SmartHeaters")
+        for smartHeater in smartHeaters:
+            _LOGGER.info(f"Creating sensor entities for SmartHeater {smartHeater.device.guid}")
+            entities.extend(
+                create_smart_heater_sensors(
+                    coordinator, device_info, smartHeater
                 )
             )
         
@@ -704,5 +733,89 @@ def create_power_meter_sensors(
             guid,
             device_name,
             lambda d: convertToKwh(get_power_meter_device(d, guid).work_out),
+        ),
+    ]
+
+
+def create_smart_heater_sensors(
+    coordinator: DataUpdateCoordinator,
+    device_info: DeviceInfo,
+    smart_heater_device: SmartHeaterDevice,
+) -> list[EnergyManagerDataSensor]:
+    """Create the sensors for a SmartHeater device."""
+    guid = smart_heater_device.device.guid
+    device_name = smart_heater_device.device.get_device_name()
+    return [
+        EnergyManagerPowerSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_POWER_AC_IN,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).power_ac_in,
+        ),
+        EnergyManagerPowerSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_POWER_AC_IN_MAX,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).power_ac_in_max,
+        ),
+        EnergyManagerPowerSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_POWER_AC_IN_LIMIT,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).power_ac_in_limit,
+        ),
+        EnergyManagerWorkSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_WORK_AC_IN,
+            device_info,
+            guid,
+            device_name,
+            lambda d: convertToKwh(get_smart_heater_device(d, guid).work_ac_in),
+        ),
+        EnergyManagerTemperatureSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_TEMPERATURE,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).temperature,
+        ),
+        EnergyManagerTemperatureSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_TEMPERATURE_BOILER,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).temperature_boiler,
+        ),
+        EnergyManagerTemperatureSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_TEMPERATURE_SET,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).temperature_set,
+        ),
+        EnergyManagerTemperatureSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_TEMPERATURE_SET_MIN,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).temperature_set_min,
+        ),
+        EnergyManagerTemperatureSensor(
+            coordinator,
+            SmartHeaterDevice.TAG_TEMPERATURE_SET_MAX,
+            device_info,
+            guid,
+            device_name,
+            lambda d: get_smart_heater_device(d, guid).temperature_set_max,
         ),
     ]

--- a/custom_components/solarwatt_energymanager/smart_heater_device.py
+++ b/custom_components/solarwatt_energymanager/smart_heater_device.py
@@ -1,0 +1,78 @@
+"""SmartHeater device wrapper.
+
+The upstream solarwatt-energymanager-py library does not model the SmartHeater
+device, so we implement the wrapper here, following the same pattern used by
+the library's other device classes (e.g. EVStationDevice).
+"""
+
+from __future__ import annotations
+
+from typing import Final, Optional
+
+import solarwatt_energymanager as em
+
+
+class SmartHeaterDevice:
+    """Wrapper for the E.G.O. SmartHeater device."""
+
+    DEVICE_CLASS: Final[str] = "com.kiwigrid.devices.smartheater.SmartHeater"
+
+    # Tag name constants
+    TAG_POWER_AC_IN: Final[str] = "PowerACIn"
+    TAG_POWER_AC_IN_MAX: Final[str] = "PowerACInMax"
+    TAG_POWER_AC_IN_LIMIT: Final[str] = "PowerACInLimit"
+    TAG_WORK_AC_IN: Final[str] = "WorkACIn"
+    TAG_TEMPERATURE: Final[str] = "Temperature"
+    TAG_TEMPERATURE_BOILER: Final[str] = "TemperatureBoiler"
+    TAG_TEMPERATURE_SET: Final[str] = "TemperatureSet"
+    TAG_TEMPERATURE_SET_MIN: Final[str] = "TemperatureSetMin"
+    TAG_TEMPERATURE_SET_MAX: Final[str] = "TemperatureSetMax"
+
+    def __init__(self, device: em.Device):
+        """Wrap a raw Device as a SmartHeaterDevice."""
+        self.device = device
+
+    @property
+    def power_ac_in(self) -> Optional[float]:
+        """Current AC power being consumed (W)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_POWER_AC_IN)
+
+    @property
+    def power_ac_in_max(self) -> Optional[float]:
+        """Maximum AC power rating (W)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_POWER_AC_IN_MAX)
+
+    @property
+    def power_ac_in_limit(self) -> Optional[float]:
+        """Current AC power limit (W)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_POWER_AC_IN_LIMIT)
+
+    @property
+    def work_ac_in(self) -> Optional[float]:
+        """Total AC energy consumed (Wh)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_WORK_AC_IN)
+
+    @property
+    def temperature(self) -> Optional[float]:
+        """Current temperature (°C)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_TEMPERATURE)
+
+    @property
+    def temperature_boiler(self) -> Optional[float]:
+        """Boiler water temperature (°C)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_TEMPERATURE_BOILER)
+
+    @property
+    def temperature_set(self) -> Optional[float]:
+        """Target temperature setpoint (°C)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_TEMPERATURE_SET)
+
+    @property
+    def temperature_set_min(self) -> Optional[float]:
+        """Minimum allowed temperature setpoint (°C)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_TEMPERATURE_SET_MIN)
+
+    @property
+    def temperature_set_max(self) -> Optional[float]:
+        """Maximum allowed temperature setpoint (°C)."""
+        return self.device.get_tag_value_as_float(SmartHeaterDevice.TAG_TEMPERATURE_SET_MAX)


### PR DESCRIPTION
## Add SmartHeater device support

### Summary

Adds support for the **E.G.O. SmartHeater** device to the SOLARWATT EnergyManager integration. The upstream `solarwatt-energymanager-py` library does not model this device, so a local wrapper is implemented following the same pattern as the library's other device classes.

### Changes

**New file: smart_heater_device.py**

A `SmartHeaterDevice` wrapper class that reads tag values directly from the raw `em.Device` object. Detected by the device class identifier `com.kiwigrid.devices.smartheater.SmartHeater`.

Exposes the following sensor values:
- `PowerACIn` — current AC power consumption (W)
- `PowerACInMax` — maximum rated AC power (W)
- `PowerACInLimit` — current AC power limit (W)
- `WorkACIn` — total AC energy consumed (kWh)
- `Temperature` — current temperature (°C)
- `TemperatureBoiler` — boiler temperature (°C)
- `TemperatureSet` — target temperature setpoint (°C)
- `TemperatureSetMin` / `TemperatureSetMax` — setpoint range bounds (°C)

**Modified: sensor_factory.py**

- Added `get_smart_heater_devices()` and `get_smart_heater_device()` helper functions that scan the raw device map for SmartHeater instances
- Added `create_smart_heater_sensors()` that creates the corresponding HA sensor entities (3 power sensors, 1 energy sensor, 5 temperature sensors)
- Extended `create_sensors()` to discover and create sensors for all SmartHeater devices found in the EnergyManager data

### Notes

- No changes to `manifest.json` — no new dependencies required
- Entity `unique_id` and `DeviceInfo` patterns are unchanged, following existing conventions
- The wrapper gracefully returns `None` for any tag not present in the API response